### PR TITLE
Add per-article OG images, short share URLs, and SEO/sharing polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ yarn-error.log*
 
 # Cloudflare
 .wrangler/
-functions/
 
 # Local test files
 *.local.json

--- a/functions/a/[code].js
+++ b/functions/a/[code].js
@@ -1,0 +1,51 @@
+/**
+ * Cloudflare Pages Function: short-link resolver.
+ *
+ * Resolves /a/<code> to its canonical article and issues a real 301 redirect.
+ * The code->path map is the build-time generated static asset /shortlinks.json,
+ * fetched once per warm isolate and cached in module scope.
+ *
+ * This directory (functions/) is auto-detected and deployed by Cloudflare Pages
+ * on every build — no dashboard configuration is required.
+ */
+
+let mapPromise = null;
+
+function loadMap(context) {
+  if (!mapPromise) {
+    const url = new URL('/shortlinks.json', context.request.url).toString();
+    // env.ASSETS serves this deployment's static files directly (no CDN round-trip);
+    // fall back to a same-origin fetch when the binding is absent.
+    const assetFetch =
+      context.env && context.env.ASSETS
+        ? (req) => context.env.ASSETS.fetch(req)
+        : (req) => fetch(req);
+    mapPromise = assetFetch(new Request(url))
+      .then((res) => (res.ok ? res.json() : {}))
+      .catch(() => ({}));
+  }
+  return mapPromise;
+}
+
+// onRequest handles GET and HEAD (crawlers / social unfurlers issue both).
+export async function onRequest(context) {
+  const code = String(context.params.code || '').toLowerCase();
+  const map = await loadMap(context);
+  const target = map[code];
+
+  if (!target) {
+    return new Response('Short link not found.', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const dest = new URL(target, context.request.url).toString();
+  return new Response(null, {
+    status: 301,
+    headers: {
+      Location: dest,
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "machine-herald",
-  "version": "3.3.0",
+  "version": "3.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "machine-herald",
-      "version": "3.3.0",
+      "version": "3.13.2",
       "dependencies": {
         "@astrojs/check": "^0.9.7",
         "@astrojs/mdx": "^5.0.0",
@@ -19,10 +19,15 @@
         "typescript": "^5.6.3"
       },
       "devDependencies": {
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/source-serif-4": "^5.2.9",
+        "@resvg/resvg-js": "^2.6.2",
         "@types/node": "^22.8.7",
         "pagefind": "^1.4.0",
         "prettier": "^3.3.3",
         "prettier-plugin-astro": "^0.14.1",
+        "satori": "^0.26.0",
         "tsx": "^4.19.2",
         "vitest": "^4.0.18"
       }
@@ -770,6 +775,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/source-serif-4": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-serif-4/-/source-serif-4-5.2.9.tgz",
+      "integrity": "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1408,6 +1443,234 @@
         "win32"
       ]
     },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1860,6 +2123,23 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2679,11 +2959,31 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2955,6 +3255,40 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -2969,6 +3303,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -3227,6 +3573,16 @@
         "@emmetio/css-abbreviation": "^2.1.8"
       }
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
@@ -3340,6 +3696,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -3538,6 +3901,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -3864,6 +4234,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-escaper": {
@@ -4305,6 +4688,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/lodash": {
@@ -5604,6 +5998,24 @@
         "@pagefind/windows-x64": "1.4.0"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -5751,6 +6163,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prettier": {
       "version": "3.8.1",
@@ -6244,6 +6663,29 @@
         "suf-log": "^2.5.3"
       }
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/sax": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
@@ -6393,6 +6835,13 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6670,6 +7119,17 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -7603,6 +8063,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,15 @@
     "typescript": "^5.6.3"
   },
   "devDependencies": {
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/source-serif-4": "^5.2.9",
+    "@resvg/resvg-js": "^2.6.2",
     "@types/node": "^22.8.7",
     "pagefind": "^1.4.0",
     "prettier": "^3.3.3",
     "prettier-plugin-astro": "^0.14.1",
+    "satori": "^0.26.0",
     "tsx": "^4.19.2",
     "vitest": "^4.0.18"
   }

--- a/public/og-default.png
+++ b/public/og-default.png
@@ -1,3 +1,0 @@
-<!-- This is a placeholder. Replace with actual OG image -->
-<!-- Recommended size: 1200x630 pixels -->
-<!-- The Machine Herald - Autonomous Newsroom -->

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "The Machine Herald",
+  "short_name": "Machine Herald",
+  "description": "Autonomous AI newsroom with verifiable provenance.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0A0A0B",
+  "theme_color": "#0A0A0B",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -8,9 +8,13 @@ const props = Astro.props as Props;
 
 const title = generateTitle(props?.title);
 const description = props?.description || SITE.description;
-const canonicalUrl = props?.canonicalUrl || new URL(Astro.url.pathname, SITE.url).toString();
+const canonicalUrl =
+  props?.canonicalUrl || new URL(Astro.url.pathname, SITE.url).toString();
 const ogImage = props?.ogImage || SITE.ogImage;
-const ogImageUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, SITE.url).toString();
+const ogImageUrl = ogImage.startsWith('http')
+  ? ogImage
+  : new URL(ogImage, SITE.url).toString();
+const ogImageAlt = props?.ogImageAlt || `${SITE.name} — autonomous AI newsroom`;
 const ogType = props?.ogType || 'website';
 ---
 
@@ -26,20 +30,33 @@ const ogType = props?.ogType || 'website';
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={ogImageUrl} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content={ogImageAlt} />
 <meta property="og:site_name" content={SITE.name} />
 <meta property="og:locale" content="en_US" />
 
-{props?.publishedTime && <meta property="article:published_time" content={props.publishedTime} />}
-{props?.modifiedTime && <meta property="article:modified_time" content={props.modifiedTime} />}
+{
+  props?.publishedTime && (
+    <meta property="article:published_time" content={props.publishedTime} />
+  )
+}
+{
+  props?.modifiedTime && (
+    <meta property="article:modified_time" content={props.modifiedTime} />
+  )
+}
 {props?.section && <meta property="article:section" content={props.section} />}
 {props?.tags?.map((tag) => <meta property="article:tag" content={tag} />)}
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content={SITE.twitterHandle} />
+<meta name="twitter:creator" content={SITE.twitterHandle} />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={ogImageUrl} />
+<meta name="twitter:image:alt" content={ogImageAlt} />
 
 <!-- Additional Meta -->
 <meta name="author" content={SITE.name} />

--- a/src/components/ShareButton.astro
+++ b/src/components/ShareButton.astro
@@ -1,0 +1,143 @@
+---
+interface Props {
+  shortUrl: string;
+  title: string;
+}
+
+const { shortUrl, title } = Astro.props;
+
+const xIntent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+  title
+)}&url=${encodeURIComponent(shortUrl)}`;
+
+const displayUrl = shortUrl.replace(/^https?:\/\//, '');
+---
+
+<div
+  class="share-bar flex flex-wrap items-center gap-2"
+  data-share
+  data-url={shortUrl}
+  data-title={title}
+>
+  <!-- Short URL + copy -->
+  <button
+    type="button"
+    data-copy
+    class="group inline-flex items-center gap-2 rounded-lg border border-border-light dark:border-border-dark px-3 py-1.5 text-xs font-mono text-text-secondary-light dark:text-text-secondary-dark hover:text-accent hover:border-accent/40 transition-colors"
+    aria-label="Copy short link"
+  >
+    <svg
+      class="size-3.5 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+      ></path>
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+      ></path>
+    </svg>
+    <span data-copy-text>{displayUrl}</span>
+  </button>
+
+  <!-- Share on X -->
+  <a
+    href={xIntent}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="inline-flex items-center gap-1.5 rounded-lg border border-border-light dark:border-border-dark px-3 py-1.5 text-xs font-mono text-text-secondary-light dark:text-text-secondary-dark hover:text-accent hover:border-accent/40 transition-colors"
+    aria-label="Share on X"
+  >
+    <svg
+      class="size-3.5 shrink-0"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+      ></path>
+    </svg>
+    <span>Post</span>
+  </a>
+
+  <!-- Native share (mobile) — revealed via JS only when supported -->
+  <button
+    type="button"
+    data-native
+    hidden
+    class="inline-flex items-center gap-1.5 rounded-lg border border-border-light dark:border-border-dark px-3 py-1.5 text-xs font-mono text-text-secondary-light dark:text-text-secondary-dark hover:text-accent hover:border-accent/40 transition-colors"
+    aria-label="Share"
+  >
+    <svg
+      class="size-3.5 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="18" cy="5" r="3"></circle>
+      <circle cx="6" cy="12" r="3"></circle>
+      <circle cx="18" cy="19" r="3"></circle>
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+    </svg>
+    <span>Share</span>
+  </button>
+</div>
+
+<script>
+  document.querySelectorAll<HTMLElement>('[data-share]').forEach((bar) => {
+    const url = bar.dataset.url ?? '';
+    const title = bar.dataset.title ?? '';
+
+    // Copy short link
+    const copyBtn = bar.querySelector<HTMLButtonElement>('[data-copy]');
+    const label = bar.querySelector<HTMLElement>('[data-copy-text]');
+    if (copyBtn && label) {
+      const original = label.textContent;
+      copyBtn.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(url);
+        } catch {
+          const ta = document.createElement('textarea');
+          ta.value = url;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          try {
+            document.execCommand('copy');
+          } catch {
+            /* ignore */
+          }
+          ta.remove();
+        }
+        label.textContent = 'Copied!';
+        copyBtn.classList.add('text-accent', 'border-accent/40');
+        window.setTimeout(() => {
+          label.textContent = original;
+          copyBtn.classList.remove('text-accent', 'border-accent/40');
+        }, 1600);
+      });
+    }
+
+    // Native share (mobile/supported browsers)
+    const nativeBtn = bar.querySelector<HTMLButtonElement>('[data-native]');
+    if (nativeBtn && typeof navigator.share === 'function') {
+      nativeBtn.hidden = false;
+      nativeBtn.addEventListener('click', () => {
+        navigator.share({ title, url }).catch(() => {
+          /* user cancelled */
+        });
+      });
+    }
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,13 +20,23 @@ const { seo, class: className } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="alternate" type="application/rss+xml" title="The Machine Herald RSS" href="/rss.xml" />
+    <link rel="apple-touch-icon" href="/logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#0A0A0B" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="The Machine Herald RSS"
+      href="/rss.xml"
+    />
     <SEO {...seo} />
     <script is:inline>
       // Theme initialization - runs before render to prevent flash
-      (function() {
+      (function () {
         const stored = localStorage.getItem('theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const prefersDark = window.matchMedia(
+          '(prefers-color-scheme: dark)'
+        ).matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
 
         if (theme === 'dark') {
@@ -37,10 +47,22 @@ const { seo, class: className } = Astro.props;
       })();
     </script>
     <!-- Privacy-friendly analytics by Plausible -->
-    <script is:inline async src="https://stats.nahi.me/js/pa-kr1kBkPQ4waX5uicvhwmn.js"></script>
+    <script
+      is:inline
+      async
+      src="https://stats.nahi.me/js/pa-kr1kBkPQ4waX5uicvhwmn.js"></script>
     <script is:inline>
-      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-      plausible.init()
+      ((window.plausible =
+        window.plausible ||
+        function () {
+          (plausible.q = plausible.q || []).push(arguments);
+        }),
+        (plausible.init =
+          plausible.init ||
+          function (i) {
+            plausible.o = i || {};
+          }));
+      plausible.init();
     </script>
   </head>
   <body class="min-h-screen flex flex-col">

--- a/src/lib/og/render.ts
+++ b/src/lib/og/render.ts
@@ -1,0 +1,324 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import satori from 'satori';
+import { Resvg } from '@resvg/resvg-js';
+
+/**
+ * Build-time Open Graph image generation.
+ *
+ * Renders a branded 1200x630 "newspaper card" per article with Satori
+ * (HTML/flexbox -> SVG) and rasterises it to PNG with resvg. Runs only during
+ * `astro build` (Node), so reading font binaries from node_modules is safe.
+ * Fonts are loaded from the committed @fontsource devDependencies (.woff is
+ * supported by Satori; .woff2 is not).
+ */
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+// Brand palette (mirrors src/styles/global.css dark surface)
+const COLORS = {
+  bg: '#0A0A0B',
+  bgAccent: '#101013',
+  title: '#FAFAFA',
+  summary: '#A1A1AA',
+  muted: '#71717A',
+  border: '#27272A',
+  accent: '#3B82F6',
+};
+
+const FONT_FILES = {
+  serif700:
+    '@fontsource/source-serif-4/files/source-serif-4-latin-700-normal.woff',
+  sans400: '@fontsource/inter/files/inter-latin-400-normal.woff',
+  sans600: '@fontsource/inter/files/inter-latin-600-normal.woff',
+  mono500:
+    '@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-normal.woff',
+} as const;
+
+function loadFont(rel: string): Buffer {
+  return readFileSync(join(process.cwd(), 'node_modules', rel));
+}
+
+type LoadedFont = {
+  name: string;
+  data: Buffer;
+  weight: 400 | 500 | 600 | 700;
+  style: 'normal';
+};
+
+// Loaded once per build process and reused across every image.
+let fontCache: LoadedFont[] | null = null;
+
+function getFonts(): LoadedFont[] {
+  if (!fontCache) {
+    fontCache = [
+      {
+        name: 'Source Serif 4',
+        data: loadFont(FONT_FILES.serif700),
+        weight: 700,
+        style: 'normal',
+      },
+      {
+        name: 'Inter',
+        data: loadFont(FONT_FILES.sans400),
+        weight: 400,
+        style: 'normal',
+      },
+      {
+        name: 'Inter',
+        data: loadFont(FONT_FILES.sans600),
+        weight: 600,
+        style: 'normal',
+      },
+      {
+        name: 'JetBrains Mono',
+        data: loadFont(FONT_FILES.mono500),
+        weight: 500,
+        style: 'normal',
+      },
+    ];
+  }
+  return fontCache;
+}
+
+const MONTHS = [
+  'JAN',
+  'FEB',
+  'MAR',
+  'APR',
+  'MAY',
+  'JUN',
+  'JUL',
+  'AUG',
+  'SEP',
+  'OCT',
+  'NOV',
+  'DEC',
+];
+
+function formatOgDate(date: Date): string {
+  return `${date.getUTCDate()} ${MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()}`;
+}
+
+function clamp(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1).trimEnd() + '…';
+}
+
+// Minimal hyperscript so we don't need JSX in a .ts module.
+type Node = { type: string; props: Record<string, unknown> };
+function h(
+  type: string,
+  style: Record<string, unknown>,
+  children?: unknown
+): Node {
+  return {
+    type,
+    props: { style, ...(children !== undefined ? { children } : {}) },
+  };
+}
+
+export interface OgCardInput {
+  title: string;
+  summary: string;
+  category?: string;
+  date?: Date;
+  model?: string;
+  /** 'article' renders the per-article card; 'default' the brand card. */
+  kind?: 'article' | 'default';
+}
+
+function buildTree(input: OgCardInput): Node {
+  const {
+    title: rawTitle,
+    summary: rawSummary,
+    category,
+    date,
+    model,
+    kind = 'article',
+  } = input;
+
+  const title = clamp(rawTitle, 150);
+  const summary = clamp(rawSummary, 200);
+
+  const kicker =
+    kind === 'article' && (category || date)
+      ? [category?.toUpperCase(), date ? formatOgDate(date) : null]
+          .filter(Boolean)
+          .join('  ·  ')
+      : 'AUTONOMOUS NEWSROOM · VERIFIABLE PROVENANCE';
+
+  const titleSize = title.length > 110 ? 54 : title.length > 70 ? 62 : 70;
+
+  return h(
+    'div',
+    {
+      width: WIDTH,
+      height: HEIGHT,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      padding: '64px 72px',
+      backgroundColor: COLORS.bg,
+      backgroundImage: `radial-gradient(circle at 88% 8%, ${COLORS.bgAccent} 0%, ${COLORS.bg} 55%)`,
+      fontFamily: 'Inter',
+    },
+    [
+      // ── Masthead row ──────────────────────────────────────
+      h(
+        'div',
+        {
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        },
+        [
+          h(
+            'div',
+            {
+              display: 'flex',
+              fontFamily: 'JetBrains Mono',
+              fontSize: 26,
+              fontWeight: 500,
+              letterSpacing: '0.18em',
+              color: COLORS.title,
+            },
+            'THE MACHINE HERALD'
+          ),
+          h('div', { display: 'flex', alignItems: 'center' }, [
+            h('div', {
+              display: 'flex',
+              width: 14,
+              height: 14,
+              borderRadius: 3,
+              backgroundColor: COLORS.accent,
+              marginRight: 12,
+              transform: 'rotate(45deg)',
+            }),
+            h(
+              'div',
+              {
+                display: 'flex',
+                fontFamily: 'JetBrains Mono',
+                fontSize: 20,
+                fontWeight: 500,
+                letterSpacing: '0.08em',
+                color: COLORS.accent,
+              },
+              'VERIFIED'
+            ),
+          ]),
+        ]
+      ),
+
+      // ── Body ──────────────────────────────────────────────
+      h('div', { display: 'flex', flexDirection: 'column' }, [
+        h(
+          'div',
+          {
+            display: 'flex',
+            fontFamily: 'JetBrains Mono',
+            fontSize: 22,
+            fontWeight: 500,
+            letterSpacing: '0.1em',
+            color: COLORS.accent,
+            marginBottom: 24,
+          },
+          kicker
+        ),
+        h(
+          'div',
+          {
+            display: 'flex',
+            fontFamily: 'Source Serif 4',
+            fontWeight: 700,
+            fontSize: titleSize,
+            lineHeight: 1.08,
+            letterSpacing: '-0.02em',
+            color: COLORS.title,
+            maxWidth: WIDTH - 144,
+          },
+          title
+        ),
+        summary
+          ? h(
+              'div',
+              {
+                display: 'flex',
+                fontFamily: 'Inter',
+                fontWeight: 400,
+                fontSize: 28,
+                lineHeight: 1.4,
+                color: COLORS.summary,
+                marginTop: 28,
+                maxWidth: WIDTH - 144,
+              },
+              summary
+            )
+          : h('div', { display: 'flex' }, ''),
+      ]),
+
+      // ── Footer row ────────────────────────────────────────
+      h('div', { display: 'flex', flexDirection: 'column' }, [
+        h('div', {
+          display: 'flex',
+          height: 1,
+          backgroundColor: COLORS.border,
+          marginBottom: 22,
+        }),
+        h(
+          'div',
+          {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          },
+          [
+            h(
+              'div',
+              {
+                display: 'flex',
+                fontFamily: 'JetBrains Mono',
+                fontSize: 22,
+                fontWeight: 500,
+                color: COLORS.title,
+              },
+              'machineherald.io'
+            ),
+            model
+              ? h(
+                  'div',
+                  {
+                    display: 'flex',
+                    fontFamily: 'JetBrains Mono',
+                    fontSize: 20,
+                    fontWeight: 500,
+                    color: COLORS.muted,
+                  },
+                  model
+                )
+              : h('div', { display: 'flex' }, ''),
+          ]
+        ),
+      ]),
+    ]
+  );
+}
+
+export async function renderOgPng(input: OgCardInput): Promise<Uint8Array> {
+  // satori expects a React-element-like tree; our plain {type, props} matches
+  // the runtime shape it consumes, so we cast to its first-argument type.
+  const tree = buildTree(input) as unknown as Parameters<typeof satori>[0];
+  const svg = await satori(tree, {
+    width: WIDTH,
+    height: HEIGHT,
+    fonts: getFonts(),
+  });
+
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: 'width', value: WIDTH },
+    font: { loadSystemFonts: false },
+  });
+  return resvg.render().asPng();
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -3,6 +3,7 @@ export interface SEOProps {
   description?: string;
   canonicalUrl?: string;
   ogImage?: string;
+  ogImageAlt?: string;
   ogType?: 'website' | 'article';
   publishedTime?: string;
   modifiedTime?: string;
@@ -32,17 +33,22 @@ export function generateNewsArticleSchema(article: {
   sources: string[];
   url: string;
   category: string;
+  model?: string;
+  image?: string;
 }) {
   return {
     '@context': 'https://schema.org',
     '@type': 'NewsArticle',
     headline: article.title,
     description: article.summary,
+    ...(article.image ? { image: [article.image] } : {}),
     datePublished: article.date.toISOString(),
     dateModified: article.date.toISOString(),
     author: {
       '@type': 'Organization',
-      name: 'The Machine Herald',
+      name: article.model
+        ? `${article.model} (via The Machine Herald)`
+        : 'The Machine Herald',
       url: SITE.url,
     },
     publisher: {

--- a/src/lib/shortlink.ts
+++ b/src/lib/shortlink.ts
@@ -1,0 +1,32 @@
+import { createHash } from 'node:crypto';
+import { SITE } from '@/lib/seo';
+
+/**
+ * Deterministic short codes for article share links.
+ *
+ * The code is derived from a SHA-256 of the (immutable) article id, so it is
+ * stable forever and needs no persisted registry. 7 base36 chars give a
+ * 36^7 (~7.8e10) space — collision probability across thousands of articles
+ * is negligible, and the build (see shortlinks.json.ts) asserts uniqueness.
+ *
+ * Build-time only (uses node:crypto); never import into client code.
+ */
+
+const CODE_LEN = 7;
+const SPACE = 36 ** CODE_LEN; // 78_364_164_096, safely < 2^53
+
+export function shortCode(articleId: string): string {
+  const hex = createHash('sha256').update(articleId).digest('hex');
+  const n = parseInt(hex.slice(0, 12), 16) % SPACE; // 48 bits -> mod space
+  return n.toString(36).padStart(CODE_LEN, '0');
+}
+
+/** Path form, e.g. "/a/k3f9q2". */
+export function shortPath(articleId: string): string {
+  return `/a/${shortCode(articleId)}`;
+}
+
+/** Absolute URL, e.g. "https://machineherald.io/a/k3f9q2". */
+export function shortUrl(articleId: string): string {
+  return `${SITE.url}/a/${shortCode(articleId)}`;
+}

--- a/src/pages/article/[...slug].astro
+++ b/src/pages/article/[...slug].astro
@@ -6,11 +6,17 @@ import SignalPill from '@/components/SignalPill.astro';
 import HumanRequestedBadge from '@/components/HumanRequestedBadge.astro';
 import EditorCorrections from '@/components/EditorCorrections.astro';
 import RelatedArticles from '@/components/RelatedArticles.astro';
+import ShareButton from '@/components/ShareButton.astro';
 import { formatDate, getReadingTime, extractDomain } from '@/lib/utils';
 import { loadProvenance } from '@/lib/provenance';
 import { generateNewsArticleSchema, SITE } from '@/lib/seo';
+import { shortUrl } from '@/lib/shortlink';
 import { inferModel, slugifyModel } from '@/lib/models';
-import { topicSlug, getRelatedArticles, type ArticleWithMeta } from '@/lib/article-meta';
+import {
+  topicSlug,
+  getRelatedArticles,
+  type ArticleWithMeta,
+} from '@/lib/article-meta';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles');
@@ -66,6 +72,8 @@ const articleCorrections = allCorrections.find(
 );
 
 const canonicalUrl = `${SITE.url}/article/${article.id}`;
+const ogImage = `/og/${article.id}.png`;
+const articleShortUrl = shortUrl(article.id);
 const articleSchema = generateNewsArticleSchema({
   title,
   summary,
@@ -73,6 +81,8 @@ const articleSchema = generateNewsArticleSchema({
   sources,
   url: canonicalUrl,
   category,
+  model: displayModel,
+  image: `${SITE.url}${ogImage}`,
 });
 ---
 
@@ -81,6 +91,8 @@ const articleSchema = generateNewsArticleSchema({
     title,
     description: summary,
     canonicalUrl,
+    ogImage,
+    ogImageAlt: title,
     ogType: 'article',
     publishedTime: date.toISOString(),
     tags,
@@ -161,7 +173,11 @@ const articleSchema = generateNewsArticleSchema({
               {meta.data.topic}
             </a>
             <a
-              href={`/topics/${topicSlug(meta.data.topic)}/${meta.data.subcategory.toLowerCase().replace(/&/g, 'and').replace(/[^\w\s-]/g, '').replace(/\s+/g, '-')}`}
+              href={`/topics/${topicSlug(meta.data.topic)}/${meta.data.subcategory
+                .toLowerCase()
+                .replace(/&/g, 'and')
+                .replace(/[^\w\s-]/g, '')
+                .replace(/\s+/g, '-')}`}
               class="inline-flex items-center rounded-lg border border-border-light dark:border-border-dark px-3 py-1.5 text-xs font-mono text-text-secondary-light dark:text-text-secondary-dark hover:text-accent hover:border-accent/30 transition-colors"
             >
               {meta.data.subcategory}
@@ -187,6 +203,11 @@ const articleSchema = generateNewsArticleSchema({
         slug={article.id}
         sourcesCount={sources.length}
       />
+
+      <!-- Share -->
+      <div class="mt-5">
+        <ShareButton shortUrl={articleShortUrl} title={title} />
+      </div>
     </header>
 
     {

--- a/src/pages/og-default.png.ts
+++ b/src/pages/og-default.png.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from 'astro';
+import { renderOgPng } from '@/lib/og/render';
+import { SITE } from '@/lib/seo';
+
+// Brand fallback OG image for the homepage and any non-article page.
+// Replaces the old static placeholder; generated at build time.
+export const GET: APIRoute = async () => {
+  const png = await renderOgPng({
+    title: SITE.name,
+    summary:
+      'Autonomous AI newsroom. Every article cryptographically signed, editorially reviewed, and published with full provenance.',
+    kind: 'default',
+  });
+
+  return new Response(png as unknown as BodyInit, {
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+};

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -1,0 +1,35 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
+import { renderOgPng } from '@/lib/og/render';
+import { inferModel } from '@/lib/models';
+
+// One static OG image per article, generated at build time.
+// Emitted to /og/<YYYY-MM>/<slug>.png and referenced from <meta og:image>.
+export const getStaticPaths: GetStaticPaths = async () => {
+  const articles = await getCollection('articles');
+  return articles.map((article) => ({
+    params: { slug: article.id },
+    props: { article },
+  }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const { article } = props as { article: CollectionEntry<'articles'> };
+  const { title, summary, category, date, contributor_model } = article.data;
+
+  const png = await renderOgPng({
+    title,
+    summary,
+    category,
+    date,
+    model: contributor_model || inferModel(date),
+    kind: 'article',
+  });
+
+  return new Response(png as unknown as BodyInit, {
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+};

--- a/src/pages/shortlinks.json.ts
+++ b/src/pages/shortlinks.json.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { shortCode } from '@/lib/shortlink';
+
+// Build-time generated map: short code -> canonical article path.
+// Consumed at the edge by functions/a/[code].js to issue 301 redirects.
+export const GET: APIRoute = async () => {
+  const articles = await getCollection('articles');
+  const map: Record<string, string> = {};
+
+  for (const article of articles) {
+    const code = shortCode(article.id);
+    const target = `/article/${article.id}`;
+    if (map[code] && map[code] !== target) {
+      throw new Error(
+        `Short code collision on "${code}": ${map[code]} vs ${target}. ` +
+          `Increase CODE_LEN in src/lib/shortlink.ts.`
+      );
+    }
+    map[code] = target;
+  }
+
+  return new Response(JSON.stringify(map), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};


### PR DESCRIPTION
- OG images: branded 1200x630 Satori card generated per article at build
  time (title/summary/category/date/model), plus a brand default card.
  Replaces the broken og-default.png placeholder. Wired into og:image /
  twitter:image with width/height/alt.
- Short URLs: deterministic hash-based /a/<code> resolved by a Cloudflare
  Pages Function (real 301, scales past the \_redirects limit). Code->path
  map generated at build (shortlinks.json). Share component copies the short
  link, posts to X, and uses the Web Share API on mobile.
- SEO: twitter:creator, NewsArticle author=contributor model + image,
  web manifest, theme-color, apple-touch-icon.
