### PR TITLE
Fix publish workflow mislabeling commit subjects with arbitrary article titles

### DIFF
--- a/.github/workflows/publish-from-submission.yml
+++ b/.github/workflows/publish-from-submission.yml
@@ -83,14 +83,22 @@ jobs:
       - name: Get article info
         id: article
         run: |
-          # Find most recent article in monthly subfolders
-          ARTICLE_FILE=$(find src/content/articles -name "*.md" -type f | xargs ls -t | head -1)
-          FILENAME=$(basename "$ARTICLE_FILE" .md)
-          # Get month folder (e.g., 2026-02)
-          MONTH_FOLDER=$(basename $(dirname "$ARTICLE_FILE"))
-          # Full slug includes month folder (e.g., 2026-02/05-article-title)
-          SLUG="${MONTH_FOLDER}/${FILENAME}"
-          TITLE=$(grep "^title:" "$ARTICLE_FILE" | sed 's/^title:\s*//' | tr -d '"')
+          # Use the authoritative paths emitted by generate:article, which appends
+          # slug / article_path / provenance_path to $GITHUB_OUTPUT (see the generate
+          # step's id). The previous approach — find ... | ls -t | head -1 — picked an
+          # arbitrary article on a fresh runner checkout, where every .md shares the
+          # same mtime, so `ls -t` ordering was nondeterministic. That mislabeled the
+          # publish commit subject (and the summary's provenance lookup) with an
+          # unrelated article's title whenever the picked file wasn't the new one.
+          ARTICLE_FILE="${{ steps.generate.outputs.article_path }}"
+          SLUG="${{ steps.generate.outputs.slug }}"
+          if [ -z "$ARTICLE_FILE" ] || [ -z "$SLUG" ]; then
+            echo "generate:article did not emit article_path/slug"
+            exit 1
+          fi
+          # Month folder is the first path segment of the slug (e.g., 2026-02/05-x -> 2026-02)
+          MONTH_FOLDER="${SLUG%%/*}"
+          TITLE=$(grep -m1 "^title:" "$ARTICLE_FILE" | sed 's/^title:\s*//' | tr -d '"')
 
           echo "slug=$SLUG" >> $GITHUB_OUTPUT
           echo "title=$TITLE" >> $GITHUB_OUTPUT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machine-herald",
   "type": "module",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "private": true,
   "description": "The Machine Herald - Autonomous newsroom with verifiable provenance",
   "scripts": {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -12,6 +12,15 @@ export const VERSIONS_PER_PAGE = 5;
  */
 export const changelog: ChangelogEntry[] = [
   {
+    version: '3.13.3',
+    date: '2026-06-09',
+    items: [
+      '<strong>Publish commit-subject bugfix</strong> in <code>.github/workflows/publish-from-submission.yml</code>. The "Get article info" step located the just-generated article with <code>find src/content/articles -name "*.md" | xargs ls -t | head -1</code>. On a fresh runner checkout every file shares the same mtime, so <code>ls -t</code> ordering is nondeterministic — the step frequently picked an <em>unrelated</em> already-published article. Its title was then used for the publish commit subject and for the summary\'s provenance lookup, producing commits like "Publish: FDA…" whose actual contents were a different article. Observed across the 2026-06-09 batch (e.g. a Persona 6 publish committed under a stale "Kotlin 2.4.0" subject)',
+      'Fix: the step now reads the authoritative <code>article_path</code> and <code>slug</code> that <code>scripts/generate_article_from_submission.ts</code> already appends to <code>$GITHUB_OUTPUT</code> (<code>steps.generate.outputs.*</code>), deriving the month folder from the slug and the title from the correct file. Fails loudly if the generate step emitted no path. The committed article and provenance files were always correct — only the commit subject and step summary were mislabeled — so no published content is affected',
+      'No content-schema or editorial-rule change. Patch-level fix to the publish pipeline only',
+    ],
+  },
+  {
     version: '3.13.2',
     date: '2026-06-07',
     items: [


### PR DESCRIPTION
## Problem

`publish-from-submission.yml` mislabels publish commit subjects. The **Get article info** step located the just-generated article with:

```bash
ARTICLE_FILE=$(find src/content/articles -name "*.md" -type f | xargs ls -t | head -1)
```

On a fresh GitHub runner checkout every file shares the same mtime, so `ls -t` ordering is nondeterministic. The step frequently picked an **unrelated, already-published** article. Its title then drove:
- the publish commit subject, and
- the summary step's `PROVENANCE_FILE` lookup.

**Observed in the 2026-06-09 batch:** commits like `Publish: FDA Launches Real-Time Clinical Trials…` and `Publish: Kotlin 2.4.0…` whose actual committed contents were entirely different articles (ClickHouse, Persona 6, etc.).

The article `.md` and provenance `.json` files were **always correct** (staged via `git add src/content/articles/` of the genuinely-new file) — only the commit subject and step summary were wrong. No published site content was ever affected.

## Fix

The generate step (`scripts/generate_article_from_submission.ts`) **already appends** `slug`, `article_path`, and `provenance_path` to `$GITHUB_OUTPUT`. The fix reads those authoritative values via `steps.generate.outputs.*` instead of re-deriving with `ls -t`, derives the month folder from the slug, and greps the title from the **correct** file. It fails loudly if the generate step emitted no path.

No script change required — the outputs were already there, just ignored.

## Versioning

Per the project's versioning rule (pipeline-logic change → version bump + changelog), bumped `3.13.2 → 3.13.3` and added a changelog entry in `src/lib/changelog.ts`.

## Test plan
- [x] `changelog.ts` parses; new entry present (v3.13.3, 3 items)
- [x] Workflow YAML validates (js-yaml)
- [x] `npm run validate:content` → all files valid
- [ ] Next merged submission publishes with a commit subject matching its own article