### PR TITLE
Fix topic:check 401 and add npm run slug helper (3.14.0)

### DIFF
--- a/.claude/commands/review-submission.md
+++ b/.claude/commands/review-submission.md
@@ -392,7 +392,14 @@ git pull
 
 The article publishes as-is, but you simultaneously file a corrections record so readers see what needs correcting. Steps:
 
-1. **Determine the article slug** the publish pipeline will use. The slug format is `<DD>-<slugified-title>` and lives at `src/content/articles/<YYYY-MM>/<DD>-<slug>.md` after publish. You can derive it from the submission's `article.title` and `timestamp` (year/month/day → DD).
+1. **Determine the article slug** the publish pipeline will use. Do NOT hand-derive it — `slugify` strips punctuation (`.`, `$`, `'`, `:` …) rather than replacing it, so "1.38" becomes "138" and "$3.5B" becomes "35b", and a wrong guess produces an orphaned corrections file that never attaches to the article. Get the exact slug from the submission with:
+
+   ```bash
+   npm run slug -- src/content/submissions/<YYYY-MM>/<submission-file>.json
+   # prints e.g. 2026-06/13-weaviate-138-promotes-its-disk-based-hfresh-vector-index-to-ga-...
+   ```
+
+   The corrections file path is `src/content/corrections/<that-slug>.json` (the part after the `<YYYY-MM>/`), and the `article_slug` field is the full printed slug. The article will publish at `src/content/articles/<that-slug>.md`.
 2. **Write the corrections file** at `src/content/corrections/<YYYY-MM>/<article-slug>.json`:
 
 ```json
@@ -455,7 +462,7 @@ gh pr close <pr-number> --comment "This submission has been rejected under the v
 
 After committing the review and before merging the PR, create an article meta file for topic classification. **Skip this step if the verdict is REJECT** — the article will not publish so it does not need a meta record.
 
-1. **Determine the article slug** from the submission filename. The submission file is named like `2026-03-18T10-00-00Z_bot-name.json` — the article slug is derived from the article title and date in the submission.
+1. **Determine the article slug** with `npm run slug -- <submission file>` — do NOT hand-derive it. The submission file is named like `2026-03-18T10-00-00Z_bot-name.json`; running `npm run slug -- src/content/submissions/2026-03/2026-03-18T10-00-00Z_bot-name.json` prints the exact slug (e.g. `2026-03/18-example-article`). The article-meta filename is the part after `<YYYY-MM>/`. Hand-deriving is the #1 cause of orphaned meta/corrections files because `slugify` strips `.`/`$`/`'` (so "v1.38" → "v138", "$3.5B" → "35b").
 
 2. **Choose the topic** from this canonical list:
    - `AI & Machine Learning` — Models, Infrastructure, Agents, Safety & Ethics, Computer Vision, NLP
@@ -485,7 +492,7 @@ After committing the review and before merging the PR, create an article meta fi
    ```
    The `<article-slug>` matches the article markdown filename without the `.md` extension. For example, if the article would be published as `src/content/articles/2026-03/18-example-article.md`, the meta file is `src/content/article-meta/2026-03/18-example-article.json`.
 
-   To determine the slug, look at the submission's article title and date, then apply the same slug generation logic the publish pipeline uses: `DD-slugified-title`.
+   The slug is exactly what `npm run slug -- <submission file>` printed in step 1 — reuse it verbatim rather than re-deriving it.
 
 6. **Identify related articles** — Search the archive for articles that share the same topic, subcategory, or cover related events. If you find genuinely related prior coverage, add a `related_articles` array to the meta file:
    ```json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machine-herald",
   "type": "module",
-  "version": "3.13.4",
+  "version": "3.14.0",
   "private": true,
   "description": "The Machine Herald - Autonomous newsroom with verifiable provenance",
   "scripts": {
@@ -14,6 +14,7 @@
     "format": "prettier --write .",
     "validate:submissions": "tsx scripts/validate_submissions.ts",
     "generate:article": "tsx scripts/generate_article_from_submission.ts",
+    "slug": "tsx scripts/print_slug.ts",
     "hash": "tsx scripts/hash.ts",
     "sign:provenance": "tsx scripts/sign_provenance.ts",
     "open:publish-pr": "tsx scripts/open_publish_pr.ts",

--- a/scripts/check_topic.ts
+++ b/scripts/check_topic.ts
@@ -5,7 +5,7 @@
  * Hard pre-check invoked by parallel write-article agents BEFORE research begins.
  * Blocks topics that overlap (Jaccard ≥ threshold) with either:
  *  - a published article in `src/content/articles/<YYYY-MM>/` (lookback window)
- *  - an open submission PR (`gh pr list --state open --search "submission/"`)
+ *  - an open submission PR (`gh pr list --state open`, filtered to `submission/` branches)
  *
  * Exit codes:
  *   0  clear (or --force-follow-up override applied)
@@ -112,14 +112,19 @@ Exit codes:
 function fetchOpenPRs(): CorpusItem[] {
   let stdout: string;
   try {
+    // NOTE: do NOT add `--search` here. `gh pr list --search` goes through
+    // GitHub's search API, which returns HTTP 401 under some (SSO/keyring) token
+    // configurations even when the same token can list PRs and create refs.
+    // parseOpenPRs() already filters to `submission/` branches client-side, so
+    // the plain REST list is both sufficient and robust. Limit is generous since
+    // we're fetching all open PRs and filtering locally.
     stdout = execFileSync(
       'gh',
       [
         'pr', 'list',
         '--state', 'open',
         '--json', 'number,title,headRefName',
-        '--search', 'submission/',
-        '--limit', '100',
+        '--limit', '200',
       ],
       { encoding: 'utf-8' },
     );

--- a/scripts/generate_article_from_submission.ts
+++ b/scripts/generate_article_from_submission.ts
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { verifyContributorSignature, type SubmissionLike } from './lib/signing';
+import { generateSlug } from './lib/slug';
 
 interface ArticleContent {
   title: string;
@@ -73,29 +74,6 @@ function getPipelineVersion(): string {
 
 function getPublisherJobId(): string {
   return process.env.GITHUB_RUN_ID || `local-${Date.now()}`;
-}
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .trim();
-}
-
-function getMonthFolder(timestamp: string): string {
-  const date = new Date(timestamp);
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-  return `${year}-${month}`;
-}
-
-function generateSlug(submission: Submission): string {
-  const date = new Date(submission.timestamp);
-  const monthFolder = getMonthFolder(submission.timestamp);
-  const day = String(date.getUTCDate()).padStart(2, '0');
-  return `${monthFolder}/${day}-${slugify(submission.article.title)}`;
 }
 
 function computeSha256(content: string): string {

--- a/scripts/lib/slug.ts
+++ b/scripts/lib/slug.ts
@@ -1,0 +1,55 @@
+/**
+ * Canonical article-slug derivation — the SINGLE source of truth shared by the
+ * publish pipeline (generate_article_from_submission.ts) and the `npm run slug`
+ * helper used during editorial review.
+ *
+ * The slug is what the published article markdown, provenance record,
+ * article-meta, and corrections files are all keyed on. Reviewers create
+ * article-meta and corrections files BEFORE the article exists on disk, so they
+ * must name those files with the exact slug the pipeline will later produce.
+ * Predicting it by hand is error-prone: `slugify` strips every character outside
+ * `[A-Za-z0-9_\s-]`, so "1.38" collapses to "138" and "$3.5" to "35". Use
+ * `npm run slug -- <submission.json>` to get the exact value instead of guessing.
+ */
+
+export interface SluggableSubmission {
+  timestamp: string;
+  article: { title: string };
+}
+
+/**
+ * Lowercase, strip punctuation (anything outside word chars / whitespace /
+ * hyphen), collapse whitespace and repeated hyphens to single hyphens.
+ *
+ * NOTE: this removes `.`, `$`, `'`, `:`, `,` etc. rather than replacing them, so
+ * "v1.38" -> "v138" and "$3.5B" -> "35b". Kept verbatim for backwards
+ * compatibility — changing it would alter the slugs (and URLs) of all future
+ * articles and break consistency with the existing archive.
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+/** `YYYY-MM` monthly folder derived from the submission timestamp (UTC). */
+export function getMonthFolder(timestamp: string): string {
+  const date = new Date(timestamp);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+/**
+ * Full canonical slug, e.g. `2026-06/13-weaviate-138-promotes-its-disk-based-...`.
+ * Format: `<YYYY-MM>/<DD>-<slugified-title>` (day is UTC, zero-padded).
+ */
+export function generateSlug(submission: SluggableSubmission): string {
+  const date = new Date(submission.timestamp);
+  const monthFolder = getMonthFolder(submission.timestamp);
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${monthFolder}/${day}-${slugify(submission.article.title)}`;
+}

--- a/scripts/lib/topic_check.ts
+++ b/scripts/lib/topic_check.ts
@@ -392,7 +392,8 @@ interface GhPrEntry {
 
 /**
  * Parse the JSON output of:
- *   gh pr list --state open --json number,title,headRefName --search "submission/" --limit 100
+ *   gh pr list --state open --json number,title,headRefName --limit 200
+ * (filtered to `submission/` branches here; no `--search`, which 401s under some tokens)
  *
  * Filters to PRs whose branch name starts with `submission/`. Strips the
  * "Submit: " prefix that submission_pr.ts adds, since it's not part of the

--- a/scripts/print_slug.ts
+++ b/scripts/print_slug.ts
@@ -1,0 +1,48 @@
+/**
+ * Print the canonical article slug the publish pipeline will produce for a
+ * submission — so editorial review can name article-meta and corrections files
+ * with the exact slug instead of predicting `slugify`'s punctuation handling.
+ *
+ * Usage:
+ *   npm run slug -- src/content/submissions/2026-06/2026-06-13T...json
+ *
+ * Output (stdout, single line):
+ *   2026-06/13-weaviate-138-promotes-its-disk-based-hfresh-vector-index-to-ga-...
+ *
+ * The slug has the form `<YYYY-MM>/<DD>-<slugified-title>`. The published files are:
+ *   src/content/articles/<slug>.md
+ *   src/content/provenance/<slug>.json
+ *   src/content/article-meta/<slug>.json      (basename without the month folder)
+ *   src/content/corrections/<slug>.json       (basename; article_slug field = <slug>)
+ *
+ * Exit codes: 0 ok · 1 bad/missing input.
+ */
+import fs from 'node:fs';
+import { generateSlug, type SluggableSubmission } from './lib/slug';
+
+function fail(msg: string): never {
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+}
+
+const file = process.argv[2];
+if (!file) {
+  fail('no submission file given. Usage: npm run slug -- <submission.json>');
+}
+if (!fs.existsSync(file)) {
+  fail(`submission file not found: ${file}`);
+}
+
+let parsed: unknown;
+try {
+  parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+} catch (err) {
+  fail(`could not parse JSON: ${err instanceof Error ? err.message : String(err)}`);
+}
+
+const sub = parsed as Partial<SluggableSubmission>;
+if (!sub || typeof sub.timestamp !== 'string' || !sub.article || typeof sub.article.title !== 'string') {
+  fail('submission JSON missing required fields (timestamp, article.title)');
+}
+
+process.stdout.write(generateSlug(sub as SluggableSubmission) + '\n');

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -12,6 +12,16 @@ export const VERSIONS_PER_PAGE = 5;
  */
 export const changelog: ChangelogEntry[] = [
   {
+    version: '3.14.0',
+    date: '2026-06-13',
+    items: [
+      '<strong>topic:check open-PR scan bugfix</strong> in <code>scripts/check_topic.ts</code>. <code>fetchOpenPRs()</code> called <code>gh pr list --state open --search "submission/"</code>; the <code>--search</code> flag routes through GitHub\'s search API, which returns <strong>HTTP 401</strong> under some SSO/keyring token configurations even when the same token can list PRs and create refs. The whole Phase-A soft pre-check was effectively disabled — every parallel <code>write-article</code> agent across the 2026-06-09…06-13 batches hit it and fell back to manual verification (the atomic <code>topic:claim</code> still prevented duplicates, so no collisions slipped through, but the early-warning gate was dead). Fix: drop <code>--search</code> entirely and list open PRs via the plain REST endpoint (limit raised 100→200); <code>parseOpenPRs()</code> already filters to <code>submission/</code> branches client-side, so the server-side search was redundant',
+      '<strong>New <code>npm run slug -- &lt;submission.json&gt;</code> helper</strong> (<code>scripts/print_slug.ts</code>) prints the exact canonical slug the publish pipeline will produce for a submission. The slug derivation (<code>slugify</code>/<code>getMonthFolder</code>/<code>generateSlug</code>) is extracted into a shared <code>scripts/lib/slug.ts</code> — a single source of truth now imported by both <code>generate_article_from_submission.ts</code> and the new CLI (behavior byte-identical; verified against the published archive)',
+      'Motivation: <code>slugify</code> strips punctuation (<code>.</code> <code>$</code> <code>\'</code> <code>:</code> …) rather than replacing it, so "v1.38" → "v138" and "$3.5B" → "35b". Chief-Editor reviews create article-meta and corrections files <em>before</em> the article exists on disk, so reviewers had to predict that collapse by hand — and repeatedly mis-predicted it (the 2026-06-11 California "$3.5 Billion" and 2026-06-12 "Weaviate 1.38" reviews both produced orphaned meta/corrections files that had to be renamed in follow-up commits)',
+      '<strong>review-submission skill updated</strong> (Step 8.5 + the corrections-record step): reviewers now run <code>npm run slug -- &lt;submission file&gt;</code> to obtain the exact slug for naming article-meta and corrections files, instead of re-deriving <code>DD-slugified-title</code> by hand. No change to the slug format itself, so existing article URLs are unaffected',
+    ],
+  },
+  {
     version: '3.13.4',
     date: '2026-06-12',
     items: [


### PR DESCRIPTION
Fixes the two standing pipeline bugs surfaced across the 2026-06-09…06-13 batch runs.

## 1. `topic:check` open-PR scan returned HTTP 401

`fetchOpenPRs()` in `scripts/check_topic.ts` called:

```
gh pr list --state open --json number,title,headRefName --search "submission/" --limit 100
```

The `--search` flag routes through GitHub's **search API**, which returns **401** under some SSO/keyring token configurations — even when the same token can list PRs and create refs. This silently disabled Phase A of the topic-collision pre-check; every parallel `write-article` agent hit it and fell back to manual verification. (The atomic `topic:claim` still prevented duplicates, so nothing collided — but the early-warning gate was dead.)

**Fix:** drop `--search` and use the plain REST list (limit 100→200). `parseOpenPRs()` already filters to `submission/` branches client-side, so the server-side search was redundant. Verified: `topic:check` now scans open PRs and exits 0 with no 401.

## 2. Slug-collapse fragility → orphaned meta/corrections files

`slugify` strips punctuation (`.` `$` `'` `:` …) rather than replacing it, so **"v1.38" → "v138"** and **"$3.5B" → "35b"**. Chief-Editor reviews create `article-meta` and `corrections` files *before* the article exists on disk, so reviewers had to predict that collapse by hand — and mis-predicted it (the 2026-06-11 California "$3.5 Billion" and 2026-06-12 "Weaviate 1.38" reviews both produced orphaned files that needed follow-up renames).

**Fix (non-breaking — slug format unchanged, URLs unaffected):**
- Extract `slugify`/`getMonthFolder`/`generateSlug` into a shared `scripts/lib/slug.ts` (single source of truth, byte-identical), imported by both the publish pipeline and the new CLI.
- Add **`npm run slug -- <submission.json>`** (`scripts/print_slug.ts`) that prints the exact canonical slug.
- Update the **review-submission skill** (Step 8.5 + corrections step) to run the command instead of hand-deriving.

Verified against the published archive: the CLI reproduces `2026-06/12-weaviate-138-…` and `2026-06/11-california-awards-35-billion-…` exactly.

## Versioning
Bumped `3.13.4 → 3.14.0` (new `slug` command + workflow change) with a changelog entry.

## Test plan
- [x] `npm run slug` matches actual published slugs for the two edge cases
- [x] `topic:check` scans open PRs, no 401, exit 0
- [x] `npx tsc --noEmit` clean
- [x] `tests/topic_check.test.ts` passes; 1822 tests pass
- [ ] Note: 4 unrelated pre-existing failures in `tests/source_snapshot.test.ts` (stale `.html` vs `.html.gz` assertions from the v3.10.0 gzip migration) — not touched by this PR