### PR TITLE
Fix binary source-snapshot corruption (pipeline 3.14.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machine-herald",
   "type": "module",
-  "version": "3.14.6",
+  "version": "3.14.7",
   "private": true,
   "description": "The Machine Herald - Autonomous newsroom with verifiable provenance",
   "scripts": {

--- a/scripts/lib/source_snapshot.ts
+++ b/scripts/lib/source_snapshot.ts
@@ -1,8 +1,10 @@
 /**
  * Source Snapshot Module
  *
- * Fetches source URLs, saves HTML snapshots to disk, and produces
- * a manifest with per-source metadata (status, hash, content-type).
+ * Fetches source URLs, saves snapshots to disk, and produces a manifest with
+ * per-source metadata (status, hash, content-type). Textual sources (HTML/XML/
+ * JSON) are stored as decoded UTF-8; binary sources (e.g. application/pdf) are
+ * stored as the exact bytes received — never lossily UTF-8-decoded.
  * Used by the chief editor review script and the standalone CLI.
  */
 
@@ -96,6 +98,39 @@ function extractDomain(url: string): string | null {
   }
 }
 
+/**
+ * Whether a response body should be stored as decoded UTF-8 text (honoring the
+ * response charset via res.text()) rather than as raw bytes. Everything that is
+ * not textual — PDFs, images, octet-streams — is stored byte-for-byte, because
+ * res.text() replaces any non-UTF-8 byte with U+FFFD and corrupts binary content
+ * before it is hashed. A null/absent content-type defaults to text, preserving
+ * the module's historical behavior for untyped responses.
+ */
+function isTextualContentType(contentType: string | null): boolean {
+  if (!contentType) return true;
+  const type = contentType.split(';', 1)[0]!.trim().toLowerCase();
+  if (type.startsWith('text/')) return true;
+  if (type.endsWith('+xml') || type.endsWith('+json')) return true;
+  return (
+    type === 'application/xml' ||
+    type === 'application/json' ||
+    type === 'application/javascript' ||
+    type === 'application/ecmascript'
+  );
+}
+
+/**
+ * Snapshot filename extension for a content type. Textual sources keep the
+ * historical `.html.gz` name; PDFs and other binaries get an accurate extension
+ * so reviewers know which tool to open them with.
+ */
+function snapshotExtension(contentType: string | null): string {
+  if (isTextualContentType(contentType)) return 'html';
+  const type = (contentType ?? '').split(';', 1)[0]!.trim().toLowerCase();
+  if (type === 'application/pdf') return 'pdf';
+  return 'bin';
+}
+
 function getMonthFromSubmissionPath(submissionPath: string): string {
   const basename = path.basename(submissionPath, '.json');
   const match = basename.match(/^(\d{4}-\d{2})/);
@@ -110,7 +145,8 @@ interface FetchAttemptResult {
   status_code: number | null;
   content_type: string | null;
   redirected_domain: string | null;
-  body: string | null;
+  /** Exact bytes to persist: decoded UTF-8 for text, raw bytes for binary. */
+  body: Buffer | null;
   error: string | null;
 }
 
@@ -150,7 +186,13 @@ async function attemptFetch(
       };
     }
 
-    const body = await res.text();
+    // Textual sources are stored as decoded UTF-8 (res.text() honors the response
+    // charset); binary sources are stored as the exact bytes received. Reading a
+    // binary body with res.text() would replace every non-UTF-8 byte with U+FFFD,
+    // corrupting the snapshot before it is hashed.
+    const body = isTextualContentType(contentType)
+      ? Buffer.from(await res.text(), 'utf-8')
+      : Buffer.from(await res.arrayBuffer());
     return {
       status_code: statusCode,
       content_type: contentType,
@@ -203,19 +245,19 @@ async function fetchSource(
     const archiveAttempt = await attemptFetch(archiveUrl, url, timeoutMs);
 
     if (archiveAttempt.status_code !== null && archiveAttempt.status_code < 400 && archiveAttempt.body !== null) {
-      const filename = `source-${index}.html.gz`;
+      const filename = `source-${index}.${snapshotExtension(archiveAttempt.content_type)}.gz`;
       const filePath = path.join(outDir, filename);
-      const utf8Bytes = Buffer.from(archiveAttempt.body, 'utf-8');
+      const bytes = archiveAttempt.body;
       // sha256 is of the uncompressed content, so verifiers decompress and rehash to check.
-      const hash = crypto.createHash('sha256').update(utf8Bytes).digest('hex');
-      fs.writeFileSync(filePath, zlib.gzipSync(utf8Bytes, { level: 9 }));
+      const hash = crypto.createHash('sha256').update(bytes).digest('hex');
+      fs.writeFileSync(filePath, zlib.gzipSync(bytes, { level: 9 }));
 
       return {
         url,
         file: filename,
         status_code: archiveAttempt.status_code,
         content_type: archiveAttempt.content_type,
-        content_length: utf8Bytes.length,
+        content_length: bytes.length,
         sha256: hash,
         error: null,
         fetched_at: fetchedAt,
@@ -228,19 +270,19 @@ async function fetchSource(
 
   // Save snapshot if we have content
   if (attempt.body !== null) {
-    const filename = `source-${index}.html.gz`;
+    const filename = `source-${index}.${snapshotExtension(attempt.content_type)}.gz`;
     const filePath = path.join(outDir, filename);
-    const utf8Bytes = Buffer.from(attempt.body, 'utf-8');
+    const bytes = attempt.body;
     // sha256 is of the uncompressed content, so verifiers decompress and rehash to check.
-    const hash = crypto.createHash('sha256').update(utf8Bytes).digest('hex');
-    fs.writeFileSync(filePath, zlib.gzipSync(utf8Bytes, { level: 9 }));
+    const hash = crypto.createHash('sha256').update(bytes).digest('hex');
+    fs.writeFileSync(filePath, zlib.gzipSync(bytes, { level: 9 }));
 
     return {
       url,
       file: filename,
       status_code: attempt.status_code,
       content_type: attempt.content_type,
-      content_length: utf8Bytes.length,
+      content_length: bytes.length,
       sha256: hash,
       error: null,
       fetched_at: fetchedAt,

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -12,6 +12,14 @@ export const VERSIONS_PER_PAGE = 5;
  */
 export const changelog: ChangelogEntry[] = [
   {
+    version: '3.14.7',
+    date: '2026-07-19',
+    items: [
+      '<strong>Binary source-snapshot corruption bugfix</strong> in <code>scripts/lib/source_snapshot.ts</code>. The snapshot fetcher read every response body with <code>res.text()</code> and re-encoded it via <code>Buffer.from(body, \'utf-8\')</code> before hashing. For binary sources — most importantly the primary-source PDFs some articles cite (court filings, SEC/press-release PDFs) — every byte that is not valid UTF-8 was replaced with the U+FFFD replacement character (<code>0xEF 0xBF 0xBD</code>) at the <code>res.text()</code> step, so the committed snapshot was a mangled file from which <code>pdftotext</code>/<code>pypdf</code> extracted zero usable text. Because the corruption happened <em>before</em> the sha256 was computed, the manifest hash still matched the (corrupted) bytes, masking the defect — a Chief Editor verifying the snapshot got a hash-valid but unreadable PDF and had to fall back to a live fetch (observed on the 2026-07-13 Ford/JD-Power review PR #1922 and the 2026-07-19 Google/Sensory antitrust review PR #1978, both citing a court/press PDF)',
+      'Fix: the fetcher now inspects the response <code>Content-Type</code>. Textual sources (<code>text/*</code>, <code>application/xml</code>/<code>+xml</code>, <code>application/json</code>/<code>+json</code>, JavaScript; and untyped responses, preserving prior behavior) are still stored as decoded UTF-8 via <code>res.text()</code>, so HTML snapshots — including non-UTF-8 pages transcoded to UTF-8 — are byte-for-byte unchanged. Binary sources are stored as the exact bytes received via <code>res.arrayBuffer()</code>, and the sha256 is computed over those true bytes, so a verifier\'s decompress-and-rehash check now passes against a genuine, openable file. Applies to both the direct-fetch and archive.org-fallback paths. Snapshot filenames now carry an accurate extension (<code>.pdf.gz</code> for PDFs, <code>.bin.gz</code> for other binaries, <code>.html.gz</code> unchanged for text) so reviewers know which tool to open them with. Covered by regression tests in <code>tests/source_snapshot.test.ts</code> (binary PDF round-trips byte-identically with no U+FFFD, via both direct and archive paths; multi-byte-UTF-8 HTML remains byte-identical). Existing committed snapshots are left untouched; only newly captured sources benefit',
+    ],
+  },
+  {
     version: '3.14.6',
     date: '2026-07-19',
     items: [

--- a/tests/source_snapshot.test.ts
+++ b/tests/source_snapshot.test.ts
@@ -35,6 +35,17 @@ function makeResponse(body: string, init?: ResponseInit & { url?: string }): Res
   return res;
 }
 
+function makeBinaryResponse(
+  bytes: Buffer,
+  init?: ResponseInit & { url?: string },
+): Response {
+  const res = new Response(bytes, init);
+  if (init?.url) {
+    Object.defineProperty(res, 'url', { value: init.url });
+  }
+  return res;
+}
+
 // ── slugify ───────────────────────────────────────────────
 
 describe('slugify', () => {
@@ -326,5 +337,111 @@ describe('fetchAndSnapshotSources', () => {
     expect(result.allReachable).toBe(false);
     expect(result.sources[0]!.status_code).toBe(403);
     expect(result.sources[0]!.archive_fallback).toBeUndefined();
+  });
+
+  // A minimal PDF: the second line is a binary marker (0xE2 0xE3 0xCF 0xD3) that
+  // is NOT valid UTF-8. A lossy `res.text()` decode replaces those bytes with the
+  // U+FFFD replacement character (0xEF 0xBF 0xBD), corrupting the snapshot before
+  // it is hashed — the exact defect seen on PR #1922 and PR #1978.
+  const pdfBytes = Buffer.from([
+    0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a, // %PDF-1.7\n
+    0x25, 0xe2, 0xe3, 0xcf, 0xd3, 0x0a, //                   %âãÏÓ\n (binary marker)
+    0xde, 0xad, 0xbe, 0xef, //                               arbitrary binary bytes
+    0x0a, 0x25, 0x25, 0x45, 0x4f, 0x46, 0x0a, //             \n%%EOF\n
+  ]);
+
+  it('preserves raw bytes for binary (application/pdf) sources without UTF-8 corruption', async () => {
+    mockFetch((url) =>
+      makeBinaryResponse(pdfBytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/pdf' },
+        url,
+      }),
+    );
+
+    const result = await fetchAndSnapshotSources(
+      ['https://business.cch.com/complaint.pdf'],
+      submissionPath,
+      articleTitle,
+      { baseDir: tmpDir },
+    );
+
+    expect(result.allReachable).toBe(true);
+    expect(result.sources[0]!.status_code).toBe(200);
+    expect(result.sources[0]!.file).toBe('source-0.pdf.gz');
+
+    // Decompress and confirm the stored bytes are byte-for-byte identical to what
+    // the server sent — no U+FFFD replacement characters anywhere.
+    const savedBytes = zlib.gunzipSync(
+      fs.readFileSync(path.join(result.snapshotDir, 'source-0.pdf.gz')),
+    );
+    expect(Buffer.compare(savedBytes, pdfBytes)).toBe(0);
+    expect(savedBytes.includes(Buffer.from([0xef, 0xbf, 0xbd]))).toBe(false);
+
+    // sha256 must be the hash of the true bytes, so a verifier's decompress-and-rehash
+    // check passes against the genuine PDF.
+    const expectedHash = crypto.createHash('sha256').update(pdfBytes).digest('hex');
+    expect(result.sources[0]!.sha256).toBe(expectedHash);
+    expect(result.sources[0]!.content_length).toBe(pdfBytes.length);
+  });
+
+  it('preserves raw bytes for a PDF fetched via the archive.org fallback', async () => {
+    mockFetch((url) => {
+      if (url.startsWith('https://web.archive.org/')) {
+        return makeBinaryResponse(pdfBytes, {
+          status: 200,
+          headers: { 'Content-Type': 'application/pdf' },
+          url,
+        });
+      }
+      return makeResponse('Forbidden', { status: 403, statusText: 'Forbidden', url });
+    });
+
+    const result = await fetchAndSnapshotSources(
+      ['https://paywalled.com/ruling.pdf'],
+      submissionPath,
+      articleTitle,
+      { baseDir: tmpDir, retryDelayMs: 0 },
+    );
+
+    expect(result.allReachable).toBe(true);
+    expect(result.sources[0]!.archive_fallback).toBe(true);
+    expect(result.sources[0]!.file).toBe('source-0.pdf.gz');
+
+    const savedBytes = zlib.gunzipSync(
+      fs.readFileSync(path.join(result.snapshotDir, 'source-0.pdf.gz')),
+    );
+    expect(Buffer.compare(savedBytes, pdfBytes)).toBe(0);
+  });
+
+  it('keeps textual (HTML) snapshots byte-identical to the UTF-8 body (no charset regression)', async () => {
+    // Includes a multi-byte UTF-8 character to prove text bytes survive intact.
+    const html = '<html><body>Résumé — café ☕ 日本語</body></html>';
+
+    mockFetch((url) =>
+      makeResponse(html, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        url,
+      }),
+    );
+
+    const result = await fetchAndSnapshotSources(
+      ['https://example.com/unicode'],
+      submissionPath,
+      articleTitle,
+      { baseDir: tmpDir },
+    );
+
+    expect(result.sources[0]!.file).toBe('source-0.html.gz');
+    const savedHtml = zlib
+      .gunzipSync(fs.readFileSync(path.join(result.snapshotDir, 'source-0.html.gz')))
+      .toString('utf-8');
+    expect(savedHtml).toBe(html);
+    const expectedHash = crypto
+      .createHash('sha256')
+      .update(Buffer.from(html, 'utf-8'))
+      .digest('hex');
+    expect(result.sources[0]!.sha256).toBe(expectedHash);
   });
 });


### PR DESCRIPTION
## Problem

The source-snapshot fetcher (`scripts/lib/source_snapshot.ts`) read **every** response body with `res.text()` and re-encoded it via `Buffer.from(body, 'utf-8')` before hashing. For binary sources — the primary-source PDFs some articles cite (court filings, SEC/press-release PDFs) — every byte that is not valid UTF-8 was replaced with the U+FFFD replacement character (`0xEF 0xBF 0xBD`) at the `res.text()` step, so the committed snapshot was a mangled file from which `pdftotext`/`pypdf` extracted zero usable text.

Because the corruption happened **before** the sha256 was computed, the manifest hash still matched the corrupted bytes, masking the defect — a Chief Editor verifying the snapshot got a hash-valid but unreadable PDF and had to fall back to a live fetch. Observed on the 2026-07-13 Ford/JD-Power review (PR #1922) and the 2026-07-19 Google/Sensory antitrust review (PR #1978), both citing a court/press PDF.

## Fix

The fetcher now inspects the response `Content-Type`:

- **Textual sources** (`text/*`, `application/xml`/`+xml`, `application/json`/`+json`, JavaScript; and untyped responses, preserving prior behavior) are still stored as decoded UTF-8 via `res.text()` — HTML snapshots, including non-UTF-8 pages transcoded to UTF-8, are **byte-for-byte unchanged**.
- **Binary sources** are stored as the exact bytes received via `res.arrayBuffer()`, and the sha256 is computed over those true bytes, so a verifier's decompress-and-rehash check passes against a genuine, openable file.
- Applies to both the direct-fetch and archive.org-fallback paths.
- Snapshot filenames now carry an accurate extension (`.pdf.gz` for PDFs, `.bin.gz` for other binaries, `.html.gz` unchanged for text).

Existing committed snapshots are **left untouched** (they are hash-verified as-is); only newly captured sources benefit.

## Verification

- Regression tests added in `tests/source_snapshot.test.ts`: a binary PDF (with bytes that are invalid UTF-8) round-trips byte-identically with no U+FFFD, via both the direct and archive paths; multi-byte-UTF-8 HTML remains byte-identical. TDD: confirmed the new tests fail against the old code before the fix.
- Full suite: **2168/2168** tests pass. `astro check`: **0 errors**.

## Versioning

Pipeline logic change → bumped `package.json` 3.14.6 → 3.14.7 and added a changelog entry in `src/lib/changelog.ts` (per CLAUDE.md). `pipeline_version` in provenance records derives from `package.json`, so future records stamp 3.14.7 automatically.